### PR TITLE
Added axe-core via addScriptTag so axe available on client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,10 @@ const spinner2 = ora('now reporting...\n')
       const service = createExecutionService(workers, stories, (story) => async (worker) => {
         await worker.setCurrentStory(story)
         await new MetricsWatcher(worker.page).waitForStable()
+        // Add axe-core to page.
+        await worker.page.addScriptTag({
+          path: require.resolve('axe-core')
+        })
         const runResults = await worker.page.evaluate((story) => {
           const getElement = () => {
             return document.getElementById('root') || document
@@ -146,18 +150,21 @@ const spinner2 = ora('now reporting...\n')
             )
           }
           // @ts-ignore
-          const axe: typeof Axe = window['axe']
           const { element = getElement(), config, options = {}, disable } = getParams(story.id)
+          // @ts-ignore
           axe.reset()
           if (disable) {
             return null
           }
           if (config) {
+            // @ts-ignore
             axe.configure(config)
           }
+          // @ts-ignore
           return axe.run(element, options)
         }, story)
         return (
+          // @ts-ignore
           runResults?.violations.map((violation) => ({
             violationId: violation.id,
             storyId: story.id,


### PR DESCRIPTION
Instead of relying on the storybook-a11y-addon to provide axe-core (which doesn't work as of Storybook 6.4) this PR adds axe-core to the page via Puppeteer page.addScriptTag API . The page can then access and run Axe tests on elements as before.

See #32 