### PR TITLE
Feat: format report in html

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npx storybook-a11y-report
 --exit, -q      The process will be terminated abnormally, if there is an a11y violation in the report result (mainly for CI)
 --storybookUrl  URL of Storybook (default: 'http://localhost:6006')
 --outDir        Directory to output the report file (default: '__report__')
+--outputFormat  Format of the output report, supports md or html (default: md)
 ```
 
 ## Built With

--- a/examples/v6-ignore-globaly/__report-all__/a11y_report.html
+++ b/examples/v6-ignore-globaly/__report-all__/a11y_report.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Accessibility report</title>
+    </head>
+    <body>
+        <h1>Accessibility report</h1><ul><li>filter: </li><li>omit: </li><li>include: </li><li>exclude: </li></ul><h2>2 violations have been found</h2><h3>A11y ID: color-contrast</h3><p>Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-button--inaccessible" target="_blank">example-button--inaccessible</a></li></ul><h3>A11y ID: label</h3><p>Description: Ensures every form element has a label<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-form--basic" target="_blank">example-form--basic</a></li></ul>
+    </body>
+</html>

--- a/examples/v6-ignore-globaly/__report-all__/a11y_report.md
+++ b/examples/v6-ignore-globaly/__report-all__/a11y_report.md
@@ -1,9 +1,20 @@
-filter: 
-omit: 
-include: 
-exclude: 
+# Accessibility report
+- filter: 
+- omit: 
+- include: 
+- exclude: 
 
-A11y ID: label
-description: Ensures every form element has a label
+## 2 violations have been found
+### A11y ID: color-contrast
+Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+
 Detected on:
-    http://localhost:6006/?path=/story/example-form--basic
+- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
+)
+
+### A11y ID: label
+Description: Ensures every form element has a label
+
+Detected on:
+- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
+)

--- a/examples/v6-ignore-globaly/package.json
+++ b/examples/v6-ignore-globaly/package.json
@@ -18,7 +18,8 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "a11y-report": "storybook-a11y-report --outDir '__report-all__'"
+    "a11y-report": "storybook-a11y-report --outDir '__report-all__'",
+    "a11y-report:html": "storybook-a11y-report --outDir '__report-all__' --outputFormat html"
   },
   "eslintConfig": {
     "extends": [

--- a/examples/v6.4/__report-all__/a11y_report.html
+++ b/examples/v6.4/__report-all__/a11y_report.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Accessibility report</title>
+    </head>
+    <body>
+        <h1>Accessibility report</h1><ul><li>filter: </li><li>omit: </li><li>include: </li><li>exclude: </li></ul><h2>2 violations have been found</h2><h3>A11y ID: color-contrast</h3><p>Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-button--inaccessible" target="_blank">example-button--inaccessible</a></li></ul><h3>A11y ID: label</h3><p>Description: Ensures every form element has a label<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-form--basic" target="_blank">example-form--basic</a></li></ul>
+    </body>
+</html>

--- a/examples/v6.4/__report-all__/a11y_report.md
+++ b/examples/v6.4/__report-all__/a11y_report.md
@@ -1,14 +1,20 @@
-filter: 
-omit: 
-include: 
-exclude: 
+# Accessibility report
+- filter: 
+- omit: 
+- include: 
+- exclude: 
 
-A11y ID: color-contrast
-description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
-Detected on:
-    http://localhost:6006/?path=/story/example-button--inaccessible
+## 2 violations have been found
+### A11y ID: color-contrast
+Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
 
-A11y ID: label
-description: Ensures every form element has a label
 Detected on:
-    http://localhost:6006/?path=/story/example-form--basic
+- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
+)
+
+### A11y ID: label
+Description: Ensures every form element has a label
+
+Detected on:
+- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
+)

--- a/examples/v6.4/__report-ignore-specific-component__/a11y_report.md
+++ b/examples/v6.4/__report-ignore-specific-component__/a11y_report.md
@@ -1,9 +1,13 @@
-filter: 
-omit: 
-include: 
-exclude: **/Form/**
+# Accessibility report
+- filter: 
+- omit: 
+- include: 
+- exclude: **/Form/**
 
-A11y ID: color-contrast
-description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+## 1 violations have been found
+### A11y ID: color-contrast
+Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+
 Detected on:
-    http://localhost:6006/?path=/story/example-button--inaccessible
+- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
+)

--- a/examples/v6.4/__report-ignore-specific-rule__/a11y_report.md
+++ b/examples/v6.4/__report-ignore-specific-rule__/a11y_report.md
@@ -1,10 +1,13 @@
-filter: 
-omit: color-contrast
-include: 
-exclude: 
+# Accessibility report
+- filter: 
+- omit: color-contrast
+- include: 
+- exclude: 
 
+## 1 violations have been found
+### A11y ID: label
+Description: Ensures every form element has a label
 
-A11y ID: label
-description: Ensures every form element has a label
 Detected on:
-    http://localhost:6006/?path=/story/example-form--basic
+- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
+)

--- a/examples/v6.4/package.json
+++ b/examples/v6.4/package.json
@@ -19,6 +19,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
     "a11y-report": "storybook-a11y-report --outDir '__report-all__'",
+    "a11y-report:html": "storybook-a11y-report --outDir '__report-all__' --outputFormat html",
     "a11y-report:ignore-specific-rule": "storybook-a11y-report -o color-contrast --outDir '__report-ignore-specific-rule__'",
     "a11y-report:ignore-specific-component": "storybook-a11y-report -e '**/Form/**' --outDir '__report-ignore-specific-component__'"
   },

--- a/examples/v6/__report-all__/a11y_report.html
+++ b/examples/v6/__report-all__/a11y_report.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Accessibility report</title>
+    </head>
+    <body>
+        <h1>Accessibility report</h1><ul><li>filter: </li><li>omit: </li><li>include: </li><li>exclude: </li></ul><h2>2 violations have been found</h2><h3>A11y ID: color-contrast</h3><p>Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-button--inaccessible" target="_blank">example-button--inaccessible</a></li></ul><h3>A11y ID: label</h3><p>Description: Ensures every form element has a label<p>Detected on:<br/><ul><li><a href="http://localhost:6006/?path=/story/example-form--basic" target="_blank">example-form--basic</a></li></ul>
+    </body>
+</html>

--- a/examples/v6/__report-all__/a11y_report.md
+++ b/examples/v6/__report-all__/a11y_report.md
@@ -1,14 +1,20 @@
-filter: 
-omit: 
-include: 
-exclude: 
+# Accessibility report
+- filter: 
+- omit: 
+- include: 
+- exclude: 
 
-A11y ID: color-contrast
-description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
-Detected on:
-    http://localhost:6006/?path=/story/example-button--inaccessible
+## 2 violations have been found
+### A11y ID: color-contrast
+Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
 
-A11y ID: label
-description: Ensures every form element has a label
 Detected on:
-    http://localhost:6006/?path=/story/example-form--basic
+- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
+)
+
+### A11y ID: label
+Description: Ensures every form element has a label
+
+Detected on:
+- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
+)

--- a/examples/v6/__report-ignore-specific-component__/a11y_report.md
+++ b/examples/v6/__report-ignore-specific-component__/a11y_report.md
@@ -1,9 +1,13 @@
-filter: 
-omit: 
-include: 
-exclude: **/Form/**
+# Accessibility report
+- filter: 
+- omit: 
+- include: 
+- exclude: **/Form/**
 
-A11y ID: color-contrast
-description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+## 1 violations have been found
+### A11y ID: color-contrast
+Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
+
 Detected on:
-    http://localhost:6006/?path=/story/example-button--inaccessible
+- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
+)

--- a/examples/v6/__report-ignore-specific-rule__/a11y_report.md
+++ b/examples/v6/__report-ignore-specific-rule__/a11y_report.md
@@ -1,10 +1,13 @@
-filter: 
-omit: color-contrast
-include: 
-exclude: 
+# Accessibility report
+- filter: 
+- omit: color-contrast
+- include: 
+- exclude: 
 
+## 1 violations have been found
+### A11y ID: label
+Description: Ensures every form element has a label
 
-A11y ID: label
-description: Ensures every form element has a label
 Detected on:
-    http://localhost:6006/?path=/story/example-form--basic
+- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
+)

--- a/examples/v6/package.json
+++ b/examples/v6/package.json
@@ -19,6 +19,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
     "a11y-report": "storybook-a11y-report --outDir '__report-all__'",
+    "a11y-report:html": "storybook-a11y-report --outDir '__report-all__' --outputFormat html",
     "a11y-report:ignore-specific-rule": "storybook-a11y-report -o color-contrast --outDir '__report-ignore-specific-rule__'",
     "a11y-report:ignore-specific-component": "storybook-a11y-report -e '**/Form/**' --outDir '__report-ignore-specific-component__'"
   },

--- a/src/htmlReporter.ts
+++ b/src/htmlReporter.ts
@@ -1,0 +1,53 @@
+import { Result } from './result'
+import { formatResults } from './resultsFormatter'
+
+const createHtmlReportMessage = (
+  storybookUrl: string,
+  violationId: string,
+  violations: Result[],
+) => {
+  const formattedViolation = violations
+    .sort((a, b) => (a.storyId > b.storyId ? 1 : a.storyId < b.storyId ? -1 : 0))
+    .reduce(
+      (acc, { storyId }) =>
+        (acc += `<li><a href="${storybookUrl}/?path=/story/${storyId}" target="_blank">${storyId}</a></li>`),
+      `<h3>A11y ID: ${violationId}</h3><p>Description: ${violations[0].description}<p>Detected on:<br/><ul>`,
+    )
+
+  return `${formattedViolation}</ul>`
+}
+
+export const createHtmlReport = (
+  storybookUrl: string,
+  results: {
+    [violationId: string]: Array<Result>
+  },
+  filters: string[],
+  omits: string[],
+  include: string[],
+  exclude: string[],
+) => {
+  const title = '<h1>Accessibility report</h1>'
+  const commandOptions = `<ul><li>filter: ${filters}</li><li>omit: ${omits}</li><li>include: ${include}</li><li>exclude: ${exclude}</li></ul>`
+  const { formattedResults, violationsCount } = formatResults(
+    createHtmlReportMessage,
+    storybookUrl,
+    results,
+    filters,
+    omits,
+  )
+  const details = formattedResults.length
+    ? `<h2>${violationsCount} violations have been found</h2>${formattedResults.join('')}`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Accessibility report</title>
+    </head>
+    <body>
+        ${title}${commandOptions}${details}
+    </body>
+</html>`
+}

--- a/src/markdownReporter.ts
+++ b/src/markdownReporter.ts
@@ -1,0 +1,36 @@
+import { Result } from './result'
+import { formatResults } from './resultsFormatter'
+
+const createMdReportMessage = (storybookUrl: string, violationId: string, violations: Result[]) => {
+  return violations
+    .sort((a, b) => (a.storyId > b.storyId ? 1 : a.storyId < b.storyId ? -1 : 0))
+    .reduce(
+      (acc, { storyId }) => (acc += `- [${storyId}](${storybookUrl}/?path=/story/${storyId}\n)`),
+      `### A11y ID: ${violationId}\nDescription: ${violations[0].description}\n\nDetected on:\n`,
+    )
+}
+export const createMdReport = (
+  storybookUrl: string,
+  results: {
+    [violationId: string]: Array<Result>
+  },
+  filters: string[],
+  omits: string[],
+  include: string[],
+  exclude: string[],
+) => {
+  const title = '# Accessibility report\n'
+  const commandOptions = `- filter: ${filters}\n- omit: ${omits}\n- include: ${include}\n- exclude: ${exclude}\n\n`
+  const { formattedResults, violationsCount } = formatResults(
+    createMdReportMessage,
+    storybookUrl,
+    results,
+    filters,
+    omits,
+  )
+  const details = formattedResults.length
+    ? `## ${violationsCount} violations have been found\n${formattedResults.join('\n\n')}`
+    : ''
+
+  return `${title}${commandOptions}${details}`
+}

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,0 +1,5 @@
+export type Result = {
+  violationId: string
+  storyId: string
+  description: string
+}

--- a/src/resultsFormatter.ts
+++ b/src/resultsFormatter.ts
@@ -1,0 +1,42 @@
+import { Result } from './result'
+
+interface CreateReportMessageFn {
+  (storybookUrl: string, violationId: string, violations: Result[]): string
+}
+
+export const formatResults = (
+  createReportMessage: CreateReportMessageFn,
+  storybookUrl: string,
+  results: {
+    [violationId: string]: Array<Result>
+  },
+  filters: string[],
+  omits: string[],
+): { formattedResults: string[]; violationsCount: number } => {
+  let violationsCount = 0
+
+  const formattedResults = Object.entries(results)
+    .map(([violationId, violations]) => {
+      if (filters.length) {
+        if (filters.includes(violationId)) {
+          violationsCount += violations.length
+          return createReportMessage(storybookUrl, violationId, violations)
+        }
+      }
+      if (omits.length) {
+        if (!omits.includes(violationId)) {
+          violationsCount += violations.length
+          return createReportMessage(storybookUrl, violationId, violations)
+        }
+      }
+      // If the "filters" and "omits" are empty, report according to all rules.
+      if (!filters.length && !omits.length) {
+        violationsCount += violations.length
+        return createReportMessage(storybookUrl, violationId, violations)
+      }
+      return ''
+    })
+    .filter((violations) => violations)
+
+  return { formattedResults, violationsCount }
+}


### PR DESCRIPTION
Hello,

Thanks for the tool, it's nice to know where to strat to improve accessibilty.

We use it for a few days and wanted to have an HTML report deployed on our gitlab pages.

This PR add this feature, if you think it could be usefull to other users. In exmaples, I only added HTML report for the `report-all` case, I could add the other if needed.

**Here is a screenshot of the HTML report:**

![Capture d’écran 2022-07-29 à 17 28 00](https://user-images.githubusercontent.com/17828760/181795311-f26fc8f0-1e36-4dd6-a18d-06d2e1c9cc87.png)

I also made a few changes to the markdwn report, I can make an other PR for this or delete the changes if you want.

### Before

filter: 
omit: 
include: 
exclude: 

A11y ID: color-contrast
description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
Detected on:
    http://localhost:6006/?path=/story/example-button--inaccessible

A11y ID: label
description: Ensures every form element has a label
Detected on:
    http://localhost:6006/?path=/story/example-form--basic
 

 ### After
 # Accessibility report
- filter: 
- omit: 
- include: 
- exclude: 

## 2 violations have been found
### A11y ID: color-contrast
Description: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds

Detected on:
- [example-button--inaccessible](http://localhost:6006/?path=/story/example-button--inaccessible
)

### A11y ID: label
Description: Ensures every form element has a label

Detected on:
- [example-form--basic](http://localhost:6006/?path=/story/example-form--basic
)