### PR TITLE
Adding ability to set timeout and loglevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npx storybook-a11y-report
 --omit, -o      ID of A11y to ignore
 --exit, -q      The process will be terminated abnormally, if there is an a11y violation in the report result (mainly for CI)
 --storybookUrl  URL of Storybook (default: 'http://localhost:6006')
+--loglevel      Set the loglevel (default: 'silent')
+--timeout       Timeout for requests (default: 30000)
 --outDir        Directory to output the report file (default: '__report__')
 --outputFormat  Format of the output report, supports md or html (default: md)
 ```


### PR DESCRIPTION
Added the following CLI options -

- timeout: (default: 30000) Set the timeout for the requests. This is useful when the requests take longer than the default.
- loglevel: (default: silent) Print the debug logs. Valid options are limited to options available in the StoryBrowser Logger (silent | normal | verbose).

Usage:
storybook-a11y-report --timeout=120000 --loglevel='silent'
